### PR TITLE
Add X11 Astrology Font handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,25 @@ OBJS = astrolog.o atlas.o calc.o charts0.o charts1.o charts2.o charts3.o\
  swecl.o swedate.o swehouse.o swejpl.o swemmoon.o swemplan.o sweph.o\
  swephlib.o
 
+# If you don't have X windows or are not using XCAIRO comment out the following
+# XCAIRO_DEBUG outputs (once) found fonts and ignores unavailable fonts.
+# For XCAIRO_DEBUG add "-lfontconfig" to the following.
+XCAIRO = -lcairo
+
 # If you don't have X windows, delete the "-lX11" part from the line below:
 # If not compiling with GNUC, delete the "-ldl" part from the line below:
-LIBS = -lm -lX11 -ldl -s
-CPPFLAGS = -O -Wno-write-strings -Wno-narrowing -Wno-comment
+LIBS = -lm -lX11 -ldl $(XCAIRO)
+
+OPT = -O -s
+#OPT = -g -O0
+WARN = -Wno-write-strings -Wno-narrowing -Wno-comment \
+       -Wno-register
+
+CPPFLAGS = $(OPT) $(WARN)
 RM = rm -f
 
 $(NAME): $(OBJS)
-	cc -o $(NAME) $(OBJS) $(LIBS)
+	cc -o $(NAME) $(OBJS) $(LIBS) $(OPT)
 
 clean:
 	$(RM) $(OBJS) $(NAME)

--- a/astrolog.h
+++ b/astrolog.h
@@ -69,6 +69,10 @@
 #define X11 /* Comment out this #define if you don't have X windows, or */
             /* else have them and don't wish to compile in X graphics.  */
 
+#define XCAIRO /* Comment out this #define if you don't have X windows,   */
+               /* or if you don't want to use the X cairo library to      */
+               /* to use and display "Astrology fonts". And see Makefile. */
+
 //#define WIN /* Comment out this #define if you don't have MS Windows, or */
             /* else have them but want a command line version instead.   */
 
@@ -326,6 +330,9 @@
 #define ISG
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#ifdef XCAIRO
+#include <cairo/cairo-xlib.h>
+#endif
 #endif
 #ifdef WIN
 #define ISG
@@ -395,6 +402,12 @@
 #error "If 'X11' is defined 'PC' must not be as well"
 #endif
 #endif // X11
+
+#ifdef XCAIRO
+#ifndef X11
+#error "If 'XCAIRO' is defined 'X11' must be too"
+#endif
+#endif // XCAIRO
 
 #ifdef WIN
 #ifndef GRAPH
@@ -1148,6 +1161,9 @@ enum _terminationcode {
 #define RgbR(l) BLo(l)
 #define RgbG(l) BHi(l)
 #define RgbB(l) ((byte)((dword)(l) >> 16 & 0xFF))
+#define RgbR01(l) ((real)RgbR(l) / 255.0)
+#define RgbG01(l) ((real)RgbG(l) / 255.0)
+#define RgbB01(l) ((real)RgbB(l) / 255.0)
 #define ChHex(n) (char)((n) < 10 ? '0' + (n) : 'a' + (n) - 10)
 
 #define Max(v1, v2) ((v1) > (v2) ? (v1) : (v2))
@@ -2065,6 +2081,9 @@ typedef struct _GraphicsInternal {
   Window wind, root;
   int screen;
   int depth;          // Number of active color bits.
+#ifdef XCAIRO
+  cairo_t *cr;        // For drawing astrology font characters on X windows.
+#endif
 #endif
 #ifdef PS             // Variables used by the PostScript generator.
   flag fEps;          // Are we doing Encapsulated PostScript.

--- a/xdata.cpp
+++ b/xdata.cpp
@@ -95,6 +95,9 @@ GI gi = {
 #endif
 #ifdef X11
   NULL, 0, 0, 0, 0, 0, 0, 0, 0,
+#ifdef XCAIRO
+  NULL,
+#endif
 #endif
 #ifdef PS
   fFalse, 0, fFalse, 0, 0, 1.0,

--- a/xgeneral.cpp
+++ b/xgeneral.cpp
@@ -75,8 +75,7 @@ void DrawColor(KI col)
       if (gi.kiCur != col) {
         PsStrokeForce();      // Render existing path with current color
         fprintf(gi.file, "%.2f %.2f %.2f c\n",
-          (real)RgbR(rgbbmp[col])/255.0, (real)RgbG(rgbbmp[col])/255.0,
-          (real)RgbB(rgbbmp[col])/255.0);
+          RgbR01(rgbbmp[col]), RgbG01(rgbbmp[col]), RgbB01(rgbbmp[col]));
       }
     }
 #endif
@@ -399,11 +398,111 @@ void AdjustGlyph(int *ch, int *x, int *y, int *fi, int *nScale,
 #endif
 
 
-#ifdef WINANY
 // Draw an astrology character from a special font on the screen. Used to draw
 // sign, planet, aspect, and Nakshatra glyphs from these fonts within charts.
+#ifdef X11
+#ifndef XCAIRO
+flag DrawGlyph(int ch, int x, int y, int fi, int nScale)
+{
+  return fFalse;
+}
+#else
+//#define XCAIRO_DEBUG
+#ifdef XCAIRO_DEBUG
+flag FFontInstalled(int);
+#endif
 
-flag WinDrawGlyph(int ch, int x, int y, int fi, int nScale)
+flag DrawGlyph(int ch, int x, int y, int fi, int nScale)
+{
+  // NOTE: ignore windows SetBkMode, DEFAULT_CHARSET, fi == fiArial && ch < 0
+
+  // Fonts: 1=Wingdings, 2=Astro, 3=EnigmaAstrology, 4=HamburgSymbols,
+  // 5=Astronomicon, 6=Courier New, 7=Consolas, 8=Arial, 9=HanksNakshatra
+
+#ifdef XCAIRO_DEBUG
+  if(!FFontInstalled(fi))
+      return fFalse;
+#endif
+
+  char symbol[4];
+  WchToUTF8(ch & 0xff, symbol);
+
+  // save current font, set new font; same thing with color.
+  cairo_font_face_t *fontPrev = cairo_get_font_face(gi.cr);
+  cairo_font_face_reference(fontPrev);
+  cairo_select_font_face (gi.cr, rgszFontName[fi],
+                          CAIRO_FONT_SLANT_NORMAL,
+                          CAIRO_FONT_WEIGHT_NORMAL);
+  cairo_set_font_size(gi.cr, 12*gi.nScale*nScale/100); // height
+  double r,g,b,a;
+  cairo_pattern_get_rgba(cairo_get_source(gi.cr), &r, &g, &b, &a);
+  int rgb = rgbbmp[gi.kiCur];
+  cairo_set_source_rgb(gi.cr, RgbR01(rgb), RgbG01(rgb), RgbB01(rgb));
+
+  // Center the text/symbol on the the given x,y position
+  cairo_text_extents_t extents;
+  cairo_text_extents (gi.cr, symbol, &extents);
+  double xAdj = x - (extents.width/2 + extents.x_bearing);
+  double yAdj = y - (extents.height/2 + extents.y_bearing);
+  cairo_move_to (gi.cr, xAdj, yAdj);
+  cairo_show_text (gi.cr, symbol);
+
+  cairo_set_source_rgba(gi.cr, r, g, b, a);
+  cairo_set_font_face(gi.cr, fontPrev);
+  cairo_font_face_destroy(fontPrev);
+  return fTrue;
+}
+
+#ifdef XCAIRO_DEBUG
+#include <string.h>
+#include <fontconfig/fontconfig.h>
+// If XCAIRO_DEBUG is enabled, use "-lfontconfig" when linking.
+// If -lcairo works, then I'm *pretty sure* fontconfig is be available.
+// NOTE: have no idea of the "right" way to use fontconfig library.
+
+// Keep an array of available fonts; indexed by _fontindex.
+static bool *font_avail;
+static void initFontAvail()
+{
+    if(font_avail != NULL)
+        return;
+    font_avail = (bool*)calloc(sizeof(bool), cFont);
+
+    FcConfig *config = FcInitLoadConfigAndFonts();
+    font_avail[fiAstrolog] = true;
+    FcResult fcr;
+    FcBool fcb;
+    int i;
+    for(i = 1; i < cFont; i++) {
+        FcPattern *checkpat = FcPatternBuild (0, FC_FAMILY, FcTypeString,
+                                              rgszFontName[i], (char *) 0);
+        // Don't understand the next two lines, but the docs are insistent.
+        FcDefaultSubstitute(checkpat);
+        FcConfigSubstitute(config, checkpat, FcMatchFont);
+        FcPattern *pat = FcFontMatch(config, checkpat, &fcr);
+        FcChar8 *family;
+        fcb = FcPatternGetString(pat, FC_FAMILY, 0, &family);
+        if(!(fcb || fcr))
+            font_avail[i] = strcmp(rgszFontName[i], (char*)family) == 0;
+    }
+    for(i = 0; i < cFont; i++)
+        fprintf(stderr, "font %d: %d - '%s'\n",
+                i, font_avail[i], rgszFontName[i]);
+
+}
+
+flag FFontInstalled(int fi)
+{
+    if(!font_avail)
+        initFontAvail();
+    return font_avail[fi];
+}
+#endif // XCAIRO_DEBUG
+#endif // XCAIRO
+#endif // X11
+
+#ifdef WINANY
+flag DrawGlyph(int ch, int x, int y, int fi, int nScale)
 {
   HFONT hfont, hfontPrev;
   SIZE size;
@@ -1234,9 +1333,9 @@ void DrawSign(int i, int x, int y)
   fDoThin = gs.fThick && nFont == 0 && ch <= 0 && gi.nScale <= gi.nScaleT;
   if (fDoThin)
     DrawThick(fFalse);
-#ifdef WINANY
+#ifdef ISG
   if (!gi.fFile && ch > 0) {
-    if (WinDrawGlyph(ch, x, y, nFont, nScale))
+    if (DrawGlyph(ch, x, y, nFont, nScale))
       return;
   }
 #endif
@@ -1295,11 +1394,11 @@ void DrawHouse(int i, int x, int y)
   fDoThin = gs.fThick && nFont == 0 && ch <= 0 && gi.nScale <= gi.nScaleT;
   if (fDoThin)
     DrawThick(fFalse);
-#ifdef WINANY
+#ifdef ISG
   if (!gi.fFile && ch > 0) {
     if (nFont == fiArial)
       ch = (i <= 9 ? '0' + i : -i);
-    if (WinDrawGlyph(ch, x, y, nFont, nScale))
+    if (DrawGlyph(ch, x, y, nFont, nScale))
       return;
   }
 #endif
@@ -1437,9 +1536,9 @@ void DrawObject(int obj, int x, int y)
   fDoThin = gs.fThick && nFont == 0 && ch <= 0 && gi.nScale <= gi.nScaleT;
   if (fDoThin)
     DrawThick(fFalse);
-#ifdef WINANY
+#ifdef ISG
   if (!gi.fFile && ch > 0) {
-    if (WinDrawGlyph(ch, x, y, nFont, nScale))
+    if (DrawGlyph(ch, x, y, nFont, nScale))
       return;
   }
 #endif
@@ -1639,9 +1738,9 @@ void DrawAspect(int asp, int x, int y)
   fDoThin = gs.fThick && nFont == 0 && ch <= 0 && gi.nScale <= gi.nScaleT;
   if (fDoThin)
     DrawThick(fFalse);
-#ifdef WINANY
+#ifdef ISG
   if (!gi.fFile && ch > 0) {
-    if (WinDrawGlyph(ch, x, y, nFont, nScale))
+    if (DrawGlyph(ch, x, y, nFont, nScale))
       return;
   }
 #endif
@@ -1697,9 +1796,9 @@ void DrawNakshatra(int i, int x, int y)
   fDoThin = gs.fThick && nFont == 0 && ch <= 0 && gi.nScale <= gi.nScaleT;
   if (fDoThin)
     DrawThick(fFalse);
-#ifdef WINANY
+#ifdef ISG
   if (!gi.fFile && ch != -1) {
-    if (WinDrawGlyph(ch, x, y, nFont, nScale))
+    if (DrawGlyph(ch, x, y, nFont, nScale))
       return;
   }
 #endif

--- a/xscreen.cpp
+++ b/xscreen.cpp
@@ -62,6 +62,9 @@
 */
 
 #ifdef X11
+#include  <unistd.h>
+#include <X11/Xatom.h>
+
 // This information used to define Astrolog's X icon (ringed planet with
 // moons) is similar to the output format used by the bitmap program. You
 // could extract this section and run "xsetroot -bitmap" on it.
@@ -316,6 +319,32 @@ LRESULT API WndProcWCLI(HWND hwnd, UINT wMsg, WPARAM wParam, LPARAM lParam)
 #endif
 
 
+#ifdef X11
+Pixmap CreatePixmap(Display *display, Drawable d,
+                    unsigned int width, unsigned int height, unsigned int depth)
+{
+  Pixmap pixmap = XCreatePixmap(display, d, width, height, depth);
+#ifdef XCAIRO
+  if(gi.cr)
+    cairo_destroy(gi.cr);
+  cairo_surface_t *sfc;
+  sfc = cairo_xlib_surface_create(display, pixmap,
+                                  DefaultVisual(display, gi.screen),
+                                  width, height);
+  gi.cr = cairo_create(sfc);
+  cairo_surface_destroy(sfc);
+#endif
+  return pixmap;
+}
+enum {
+    ATOM__NET_WM_PID,
+    ATOM_COUNT
+};
+static Atom atoms[ATOM_COUNT];
+#define INIT_ATOM_(atom) \
+            atoms[ATOM_##atom] = XInternAtom(gi.disp, #atom, False);
+#endif
+
 #ifdef ISG
 // This routine opens up and initializes a window and prepares it to be drawn
 // upon, and gets various information about the display, too.
@@ -348,12 +377,17 @@ void BeginX()
   else
     gi.wind = XCreateSimpleWindow(gi.disp, DefaultRootWindow(gi.disp),
       hint.x, hint.y, hint.width, hint.height, 5, fg, bg);
-  gi.pmap = XCreatePixmap(gi.disp, gi.wind, gs.xWin, gs.yWin, gi.depth);
+  gi.pmap = CreatePixmap(gi.disp, gi.wind, gs.xWin, gs.yWin, gi.depth);
   gi.icon = XCreateBitmapFromData(gi.disp, DefaultRootWindow(gi.disp),
     (char *)icon_bits, icon_width, icon_height);
   if (!gs.fRoot)
     XSetStandardProperties(gi.disp, gi.wind, szAppName, szAppName, gi.icon,
       (char **)xkey, 0, &hint);
+  INIT_ATOM_(_NET_WM_PID);
+  pid_t pid = getpid();
+  XChangeProperty(gi.disp, gi.wind,
+                  atoms[ATOM__NET_WM_PID], XA_CARDINAL, sizeof(pid_t) * 8,
+                  PropModeReplace, (unsigned char *) &pid, 1);
 
   // There are two graphics workareas. One is what the user currently sees in
   // the window, and the other is what is currently being drawn on. When done,
@@ -710,7 +744,7 @@ void InteractX()
 #ifdef X11
       XResizeWindow(gi.disp, gi.wind, gs.xWin, gs.yWin);
       XFreePixmap(gi.disp, gi.pmap);
-      gi.pmap = XCreatePixmap(gi.disp, gi.wind, gs.xWin, gs.yWin, gi.depth);
+      gi.pmap = CreatePixmap(gi.disp, gi.wind, gs.xWin, gs.yWin, gi.depth);
 #endif
 #ifdef WCLI
       ResizeWindowToChart();
@@ -810,7 +844,7 @@ void InteractX()
         gi.xWinResize = gs.xWin = xevent.xconfigure.width;
         gi.yWinResize = gs.yWin = xevent.xconfigure.height;
         XFreePixmap(gi.disp, gi.pmap);
-        gi.pmap = XCreatePixmap(gi.disp, gi.wind, gs.xWin, gs.yWin, gi.depth);
+        gi.pmap = CreatePixmap(gi.disp, gi.wind, gs.xWin, gs.yWin, gi.depth);
         fRedraw = fTrue;
         break;
       case MappingNotify:
@@ -1250,6 +1284,9 @@ void EndX()
 #ifdef X11
   XFreeGC(gi.disp, gi.gc);
   XFreeGC(gi.disp, gi.pmgc);
+#ifdef XCAIRO
+  cairo_destroy(gi.cr);
+#endif
   XFreePixmap(gi.disp, gi.pmap);
   XDestroyWindow(gi.disp, gi.wind);
   XCloseDisplay(gi.disp);
@@ -1258,8 +1295,9 @@ void EndX()
   UnregisterClass(szAppName, wi.hinst);
 #endif
 }
-#endif // ISG
+
 #endif // WIN
+#endif // ISG
 
 
 /*


### PR DESCRIPTION
Uses -lcairo for drawing symbols.
Add X property _NET_WM_PID for easier startup initialization from a script.