### PR TITLE
Drop usage of register storage class specifier

### DIFF
--- a/placalc.cpp
+++ b/placalc.cpp
@@ -561,8 +561,8 @@ int hel(int planet, REAL8 t, REAL8 *al, REAL8 *ar, REAL8 *az, REAL8 *alp,
 /* speed in radius, AU per day */
 /* speed in z, AU per day */
 {
-  register struct elements *e;
-  register struct eledata  *d;
+  struct elements *e;
+  struct eledata  *d;
   REAL8 lk = 0.0;
   REAL8 rk = 0.0;
   REAL8 b, h1, sini, sinv, cosi, cosu, cosv, man, truanom, esquare,
@@ -686,7 +686,7 @@ int hel(int planet, REAL8 t, REAL8 *al, REAL8 *ar, REAL8 *az, REAL8 *alp,
 }
 
 
-void disturb(register struct kor *k, REAL8 *al, REAL8 *ar, REAL8 lk, REAL8 rk,
+void disturb(struct kor *k, REAL8 *al, REAL8 *ar, REAL8 lk, REAL8 rk,
   REAL8 man)
 /* ENDMARK-terminated array of struct kor */
 /* longitude in degrees, use a pointer to return value */

--- a/placalc.h
+++ b/placalc.h
@@ -256,7 +256,7 @@ extern REAL8 test_near_zero(REAL8);
 extern REAL8 deltat(double);
 extern void to_mean_ekl();
 extern int afl2planet();
-extern void disturb(register struct kor *, REAL8 *, REAL8 *, REAL8, REAL8,
+extern void disturb(struct kor *, REAL8 *, REAL8 *, REAL8, REAL8,
   REAL8);
 extern REAL8 fnu(REAL8, REAL8, REAL8);
 


### PR DESCRIPTION
The register storage class specifier was deprecated in C++14 and completely removed in C++17. Thus with newer compiler (like Clang 16 and gcc 13) we get build errors with message "ISO C++17 does not allow register storage class specifier".

This patch fixes the build error.

Bug: https://bugs.gentoo.org/894524