### PR TITLE
Fix filled ellipse rendering in SVG output

### DIFF
--- a/xgeneral.cpp
+++ b/xgeneral.cpp
@@ -1019,11 +1019,24 @@ void DrawEllipse2(int x1, int y1, int x2, int y2)
     }
 #endif
 #ifdef META
-    else {
+    else if (gs.ft == ftWmf) {
       gi.kiFillDes = gi.kiCur;    // Specify a solid fill brush.
       MetaSelect();
       MetaEllipse(x1+gi.nPenWid/3, y1+gi.nPenWid/3,
         x2+1+gi.nPenWid/3, y2+1+gi.nPenWid/3);
+    }
+#endif
+#ifdef SVG
+    else if (gs.ft == ftSVG) {
+      SvgSetColor();
+      if (rx == ry)
+        fprintf(gi.file,
+          "<circle r=\"%d\" cx=\"%d\" cy=\"%d\" fill=\"%s\"/>\n",
+          rx, x, y, SzColorHTML(gi.kiSvgAct));
+      else
+        fprintf(gi.file, "<ellipse rx=\"%d\" ry=\"%d\" "
+          "cx=\"%d\" cy=\"%d\" fill=\"%s\"/>\n",
+          rx, ry, x, y, SzColorHTML(gi.kiSvgAct));
     }
 #endif
   }


### PR DESCRIPTION
## Summary

- emit filled SVG `<circle>` and `<ellipse>` elements from `DrawEllipse2()`
- restrict the metafile branch to actual `ftWmf` output

## Root cause

When a Solar System chart is zoomed closely enough for planetary disks to be
drawn, SVG output calls `DrawEllipse2()`. That function has no SVG-specific
branch, so builds with both `META` and `SVG` enabled fall through to the
metafile code. SVG output does not allocate the metafile buffer, and
`MetaSelect()` consequently dereferences a null buffer.

For example, this can reproduce the crash before the fix:

```sh
./astrolog -qb 8 5 2026 5:57pm 1 5 74W00 40N42 \
  -zi Test "New York" -S -YXS 1 -Xx0 -Xw 700 560 \
  -XV -Xo close-solar-system.svg
```

## Validation

- built Astrolog with SVG and META enabled
- rendered Solar System SVG charts at 4 AU, 1 AU, and 0.0001 AU
- confirmed successful exit and filled SVG output at each radius

This change affects SVG file output only; WMF rendering retains its existing
implementation.
