### PR TITLE
Support streaming SVG and chart data to stdout

### DIFF
--- a/charts0.cpp
+++ b/charts0.cpp
@@ -417,6 +417,7 @@ void DisplaySwitches(void)
   PrintS(" _ix: Swap contents of chart #1 and chart #2.");
   PrintS(" _o <file> [..]: Write parameters of current chart to file.");
   PrintS(" _o0 <file> [..]: Like _o but output planet/house positions.");
+  PrintS("  Use '-' as the file to write planet/house positions to stdout.");
   PrintS(" _ol <file>: Write current chart list to Astrolog chart list file.");
   PrintS(" _oa <file>: Write current chart or chart list to AAF format file.");
   PrintS(" _oq <file>: Write current chart list to Quick*Chart format file.");
@@ -1811,6 +1812,7 @@ void DisplaySwitchesX(void)
   PrintS(" _X3: Create Daedalus wireframe vector file instead of bitmap.");
 #endif
   PrintS(" _Xo <file>: Write output bitmap or graphic to specified file.");
+  PrintS("  For SVG output, use '-' as the file to write SVG to stdout.");
 #ifdef X11
   PrintS(" _XB: Display X chart on root instead of in a separate window.");
 #endif

--- a/io.cpp
+++ b/io.cpp
@@ -331,7 +331,7 @@ flag FOutputData(void)
     return FOutputDaedalusStar();
 #endif
 
-  file = fopen(is.szFileOut, "w");  // Create and open the file for output.
+  file = FEqSz(is.szFileOut, "-") ? stdout : fopen(is.szFileOut, "w");
   if (file == NULL) {
     sprintf(sz, "File '%s' can not be created.", is.szFileOut);
     PrintError(sz);
@@ -342,7 +342,8 @@ flag FOutputData(void)
     // Write the chart information to the file.
 
     if (Mon < 1) {
-      fclose(file);
+      if (file != stdout)
+        fclose(file);
       PrintError("Can't output chart with no time/space to file.");
       return fFalse;
     }
@@ -438,7 +439,10 @@ flag FOutputData(void)
 
   for (i = 0; i < is.cszComment; i++)
     fprintf(file, "%s%s\n", us.fWriteOld ? "" : "; ", is.rgszComment[i]);
-  fclose(file);
+  if (file == stdout)
+    fflush(file);
+  else
+    fclose(file);
   return fTrue;
 }
 

--- a/xdevice.cpp
+++ b/xdevice.cpp
@@ -1308,8 +1308,11 @@ flag BeginFileX()
         WaitForSingleObject(wi.hMutex, 1000);
     }
 #endif
-    gi.file = fopen(gi.szFileOut, (gs.ft == ftBmp && (gs.chBmpMode == 'B' ||
-      gs.chBmpMode == 'P')) || gs.ft == ftWmf ? "wb" : "w");
+    if (gs.ft == ftSVG && FEqSz(gi.szFileOut, "-"))
+      gi.file = stdout;
+    else
+      gi.file = fopen(gi.szFileOut, (gs.ft == ftBmp && (gs.chBmpMode == 'B' ||
+        gs.chBmpMode == 'P')) || gs.ft == ftWmf ? "wb" : "w");
     if (gi.file != NULL)
       break;
 #ifdef WIN
@@ -1373,7 +1376,11 @@ void EndFileX()
     WriteWire(gi.file);
   }
 #endif
-  fclose(gi.file);
+  if (gi.file == stdout)
+    fflush(gi.file);
+  else
+    fclose(gi.file);
+  gi.file = NULL;
 #ifdef WIN
   if (wi.fAutoSave && wi.hMutex != NULL)
     ReleaseMutex(wi.hMutex);


### PR DESCRIPTION
## Summary

- allow `-Xo -` to write SVG graphics to standard output
- allow `-o0 -` to write planet and house positions to standard output
- flush standard output instead of closing it
- document both stdout forms in the built-in switch help

## Motivation

This lets scripts and GUI integrations consume SVG and structured chart positions directly through pipes without creating temporary files. Existing named-file behavior is unchanged.

## Validation

- built Astrolog 8.00 natively on Apple Silicon
- verified streamed SVG begins with the XML declaration and ends with a complete `</svg>` document
- verified streamed `-o0` output contains the `@AP800` header and `-YF` position records
- verified both streams work in the Astrolog-AS integration without temporary chart files
